### PR TITLE
FIX: check if the 'all text' option is selected on bootstrap-multiselect

### DIFF
--- a/js/select/renderer/bootstrap.js
+++ b/js/select/renderer/bootstrap.js
@@ -24,7 +24,7 @@ var BootstrapRenderer = {
     selectedQuery: function () {
         var $widget = this.$dom.multiselect();
 
-        if ($.inArray($widget.selectAllText, $widget.val())) {
+        if ($.inArray($widget.selectAllText, $widget.val()) > -1) {
             return '';
         } else {
             return this._getSelection().map(function (value) {


### PR DESCRIPTION
As $.inArray returns an int (and have the same behavior than Array.indexOf), it always returns -1 when there is no `selectAllText`.
In this case bootstrap renderer's query is always '', so the filter doesn't work.
(This is why the example doesn't work.)

Note that I didn't add dist files in this PR, because I think it's really boring for you always deal with conflicts. Please just make sure dist is up-to-date in your own repository !