### PR TITLE
FIX: #9 Filtre sur colonne invisible

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -19,15 +19,15 @@ var Filters = function (settings) {
     var builders = this.builders;
     var renderCol = 0;
     $.each(settings.aoColumns, function (col, param) {
-        if (param.filter) {
-            var options = $.extend({
-              column: col,
-              renderColumn: renderCol
-            }, param.filter);
-            filters.push(builders[param.filter.type](options));
-        }
         if(param.bVisible) {
-          renderCol++;
+            if (param.filter) {
+                var options = $.extend({
+                    column: col,
+                    renderColumn: renderCol
+                }, param.filter);
+                filters.push(builders[param.filter.type](options));
+            }
+            renderCol++;
         }
     });
 


### PR DESCRIPTION
PR for [issue #9 ](https://github.com/Ouzned/datatable-filters/issues/9)

As Datatable add invisible columns into the DOM, this fix doesn't add filters on invisible columns anymore.

Note that dynamically show/hide column by using `column().visible()` still doesn't work. We could listen the `column-visibility.dt` event to redraw every filter at it own place.