### PR TITLE
Type text de filtre input pour style bootstrap

### DIFF
--- a/js/input/input.js
+++ b/js/input/input.js
@@ -8,7 +8,7 @@ var Filters = require('../filters');
 var InputFilter = $.extend({}, BaseFilter, SimpleRenderer, {
 
     init: function () {
-        this.$dom = $('<input class="filtre"/>');
+        this.$dom = $('<input type="text" class="filtre"/>');
         this.$dom.val(this.getInitialQuery());
         this.$dom.on('input', this.notifyChange.bind(this));
 


### PR DESCRIPTION
Pour éviter la régression sur le style des filtres input car bootstrap ne s'appliquent que sur les filtres où type="text"